### PR TITLE
Add (hopefully) useful description of Sassy Ink.

### DIFF
--- a/data/categories.yml
+++ b/data/categories.yml
@@ -87,7 +87,7 @@
       url:  "https://github.com/mailchimp/Email-Blueprints"
     - name: "Ink: A Responsive Email Framework"
       url:  "http://zurb.com/ink/"
-    - name: "Sassy Ink"
+    - name: "Sassy Ink: The Unofficial Sass port of Zurb's Ink"
       url:  "https://github.com/faustgertz/sassy-ink"
     - name: "Antwort: Responsive Layouts for Email"
       url:  "http://internations.github.io/antwort/"


### PR DESCRIPTION
Thanks for listing Sassy Ink. While the location in the list is helpful, I thought it might be even more helpful to explicitly let folks know that Sassy Ink is the _unofficial_ Sass port of Zurb's Ink.
